### PR TITLE
Version 1.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
     }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    compile('com.jackpocket:scratchoff:1.3.0')
+    compile('com.jackpocket:scratchoff:1.3.1')
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -105,18 +105,48 @@ As a final note, if using the ScratchoffController in the context of an Activity
 @Override
 public void onPause(){
     controller.onPause();
+    controller.removeTouchObservers()
+
     super.onPause();
 }
 
 @Override
 public void onResume(){
     super.onResume();
+
     controller.onResume();
+    controller.addTouchObserver((view, event) -> {
+        // Do something on MotionEvent?
+    });
 }
 
 @Override
 public void onDestroy(){
     controller.onDestroy();
+
     super.onDestroy();
+}
+```
+
+### Observing MotionEvents
+
+As of version 1.3.1, you can add an `OnTouchListener` to the `ScratchoffController` to observe `MotionEvents` as they come in, regardless of enabled state. When adding these observers, it'd be a good idea to remove them in the appropriate lifecycle methods.
+
+
+```java
+@Override
+public void onPause(){
+    controller.removeTouchObservers()
+
+    ....
+}
+
+@Override
+public void onResume(){
+    ....
+
+    controller.addTouchObserver((view, event) -> {
+        // Do something on a particular MotionEvent?
+    });
 }
 ```

--- a/scratchoff-test/build.gradle
+++ b/scratchoff-test/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 buildscript {
-    ext.kotlin_version = '1.2.51'
+    ext.kotlin_version = '1.3.20'
 
     repositories {
         jcenter()
@@ -42,7 +42,7 @@ android {
 dependencies {
     implementation project(path: ':scratchoff')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:1.0.0"
     implementation "androidx.constraintlayout:constraintlayout:1.1.2"
 

--- a/scratchoff-test/src/main/java/com/jackpocket/scratchoff/test/MainActivity.kt
+++ b/scratchoff-test/src/main/java/com/jackpocket/scratchoff/test/MainActivity.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.os.Handler
 import android.util.Log
 import android.os.Looper
+import android.view.MotionEvent
+import android.view.View
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import com.jackpocket.scratchoff.ScratchoffController
@@ -11,7 +13,7 @@ import com.jackpocket.scratchoff.processors.ThresholdProcessor
 import com.jackpocket.scratchoff.views.ScratchableLinearLayout
 import java.lang.ref.WeakReference
 
-class MainActivity: AppCompatActivity(), ThresholdProcessor.ScratchValueChangedListener {
+class MainActivity: AppCompatActivity(), ThresholdProcessor.ScratchValueChangedListener, View.OnTouchListener {
 
     private lateinit var controller: ScratchoffController
     private var scratchPercentTitleView = WeakReference<TextView>(null)
@@ -42,12 +44,14 @@ class MainActivity: AppCompatActivity(), ThresholdProcessor.ScratchValueChangedL
         super.onResume()
 
         this.controller.onResume()
+        this.controller.addTouchObserver(this)
     }
 
     override fun onPause() {
         super.onPause()
 
         this.controller.onPause()
+        this.controller.removeTouchObservers()
     }
 
     override fun onDestroy() {
@@ -58,6 +62,16 @@ class MainActivity: AppCompatActivity(), ThresholdProcessor.ScratchValueChangedL
 
     override fun onScratchPercentChanged(percentCompleted: Double) {
         scratchPercentTitleView.get()?.text = "Scratched ${percentCompleted * 100}%"
+    }
+
+    override fun onTouch(view: View, event: MotionEvent): Boolean {
+        when (event.action) {
+            MotionEvent.ACTION_DOWN -> Log.d(TAG, "Observed ACTION_DOWN")
+            MotionEvent.ACTION_UP -> Log.d(TAG, "Observed ACTION_UP")
+        }
+
+        // Our return is ignored here
+        return false
     }
 
     companion object {

--- a/scratchoff/build.gradle
+++ b/scratchoff/build.gradle
@@ -43,7 +43,7 @@ ext {
     artifact = 'scratchoff'
 
     libraryDescription = 'A Scratchoff View system.'
-    libraryVersion = '1.3.0'
+    libraryVersion = '1.3.1'
 
     developerId = 'jackpocket'
     developerName = 'Jackpocket'

--- a/scratchoff/src/main/java/com/jackpocket/scratchoff/ScratchoffController.java
+++ b/scratchoff/src/main/java/com/jackpocket/scratchoff/ScratchoffController.java
@@ -12,6 +12,7 @@ import com.jackpocket.scratchoff.processors.ThresholdProcessor;
 import com.jackpocket.scratchoff.views.ScratchableLayout;
 
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.List;
 
 public class ScratchoffController implements OnTouchListener, LayoutCallback {
@@ -38,6 +39,7 @@ public class ScratchoffController implements OnTouchListener, LayoutCallback {
     private boolean enabled = true;
 
     private long lastTouchEvent = 0;
+    private List<OnTouchListener> touchObservers = new ArrayList<OnTouchListener>();
 
     public ScratchoffController(Context context) {
         this(context, null);
@@ -116,6 +118,10 @@ public class ScratchoffController implements OnTouchListener, LayoutCallback {
 
     @Override
     public boolean onTouch(View view, MotionEvent event) {
+        for (OnTouchListener observer : touchObservers) {
+            observer.onTouch(view, event);
+        }
+
         if(!enabled)
             return false;
 
@@ -266,6 +272,26 @@ public class ScratchoffController implements OnTouchListener, LayoutCallback {
 
     public ScratchableLayoutDrawer getLayoutDrawer(){
         return layoutDrawer;
+    }
+
+    /**
+     * Add an OnTouchListener to observe MotionEvents as they are passed
+     * into the ScratchoffController. Events will be forwarded regardless of
+     * the ScratchoffController's enabled state, and all return values will be ignored.
+     *
+     * If adding observers (in Activity.onResume), you should also call
+     * ScratchoffController.removeTouchObservers (in Activity.onPause).
+     *
+     * @param touchListener a non-null OnTouchListener
+     */
+    public ScratchoffController addTouchObserver(OnTouchListener touchListener) {
+        this.touchObservers.add(touchListener);
+
+        return this;
+    }
+
+    public void removeTouchObservers() {
+        this.touchObservers.clear();
     }
 
     public void post(Runnable runnable){

--- a/scratchoff/src/main/java/com/jackpocket/scratchoff/ScratchoffController.java
+++ b/scratchoff/src/main/java/com/jackpocket/scratchoff/ScratchoffController.java
@@ -290,6 +290,17 @@ public class ScratchoffController implements OnTouchListener, LayoutCallback {
         return this;
     }
 
+    /**
+     * Remove a OnTouchListener from the ScratchoffController.
+     *
+     * @param touchListener a non-null OnTouchListener
+     */
+    public ScratchoffController removeTouchObserver(OnTouchListener touchListener) {
+        this.touchObservers.remove(touchListener);
+
+        return this;
+    }
+
     public void removeTouchObservers() {
         this.touchObservers.clear();
     }


### PR DESCRIPTION
+ Adds `ScratchoffController.addTouchObserver(OnTouchListener)` to observe motion events
+ Adds `ScratchoffController.removeTouchObserver(OnTouchListener)` to remove a single observer instance
+ Adds `ScratchoffController.removeTouchObservers()` to clear the added observers
+ Updated Gradle 3.2.1 -> 3.3.2, Kotlin 1.2.51 -> 1.3.20